### PR TITLE
ci: add GPG settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<phase>verify</phase>
+						<phase>package</phase>
 						<goals>
 							<goal>jar</goal>
 						</goals>
@@ -180,7 +180,7 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
-						<phase>verify</phase>
+						<phase>package</phase>
 						<goals>
 							<goal>jar-no-fork</goal>
 						</goals>

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,35 @@
 		</plugins>
 	</reporting>
 
+	<profiles>
+		<profile>
+			<id>gpg</id>
+			<activation>
+				<property>
+					<name>gpg.passphrase</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.1.0</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<distributionManagement>
 		<site>
 			<id>site</id>


### PR DESCRIPTION
Plugins cannot be _added_ in external settings.xml files. The external configuration was ignored (gpg:sign did never bind to the verify phase) but it ran because I had changed the goals to  `clean package source:jar javadoc:javadoc gpg:sign deploy`.  

In order to integrate with the release plugin, I think it's better that we define a profile with implicit activation (if the GPG passphrase is provided), so that the goal is just `clean deploy` using default settings.xml.