### PR TITLE
build: use version 6.0.8 of spring-expression to avoid CVE-2023-20863

### DIFF
--- a/backend-core-business-spring-impl/pom.xml
+++ b/backend-core-business-spring-impl/pom.xml
@@ -40,4 +40,13 @@
 		</dependency>
 	</dependencies>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-expression</artifactId>
+				<version>6.0.8</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 </project>


### PR DESCRIPTION
use version 6.0.8 of spring-expression to avoid  CVE-2023-20863. More information: https://github.com/advisories/GHSA-wxqc-pxw9-g2p8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management to include `spring-expression` version `6.0.8`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->