### PR TITLE
ci: break build on incompatible modifications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,28 @@
 					</execution>
 				</executions>
 			</plugin>
+			
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<version>0.25.4</version>
+				<configuration>
+					<parameter>
+						<breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+						<breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+						<breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+					</parameter>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>verify</phase>
+						<goals>
+							<goal>cmp</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			
 		</plugins>
 	</build>
 


### PR DESCRIPTION
It has come to our attention that #94 contains a binary-compatibility breaking change that was not identified during the review phase. To prevent similar regressions, I am rolling out japicmp across all add-ons and libraries. This will automate binary-compatibility checks and ensure we catch breaking changes during the CI process.

Had we run this tool on the PR, it would have immediately reported the incompatibility and blocked the release.

> [ERROR] Failed to execute goal com.github.siom79.japicmp:japicmp-maven-plugin:0.25.4:cmp (default) on project backend-core-model: There is at least one incompatibility: com.flowingcode.backendcore.model.QuerySpec.addConstraint(com.flowingcode.backendcore.model.Constraint):METHOD_RETURN_TYPE_CHANGED,com.flowingcode.backendcore.model.QuerySpec.addOrder(java.lang.String,com.flowingcode.backendcore.model.QuerySpec$Order):METHOD_RETURN_TYPE_CHANGED,com.flowingcode.backendcore.model.QuerySpec.addOrder(java.lang.String):METHOD_RETURN_TYPE_CHANGED,com.flowingcode.backendcore.model.QuerySpec.setFirstResult(java.lang.Integer):METHOD_RETURN_TYPE_CHANGED,com.flowingcode.backendcore.model.QuerySpec.setMaxResult(java.lang.Integer):METHOD_RETURN_TYPE_CHANGED,com.flowingcode.backendcore.model.QuerySpec.setOrders(java.util.Map):METHOD_RETURN_TYPE_CHANGED,com.flowingcode.backendcore.model.QuerySpec.setReturnedAttributes(java.lang.String[]):METHOD_RETURN_TYPE_CHANGED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the build process to verify API compatibility across releases, ensuring consistent interfaces and preventing unintended breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->