### PR TITLE
fix: check join type when reusing joins in ConstraintTransformerJpaImpl

### DIFF
--- a/backend-core-data-impl/src/main/java/com/flowingcode/backendcore/dao/jpa/ConstraintTransformerJpaImpl.java
+++ b/backend-core-data-impl/src/main/java/com/flowingcode/backendcore/dao/jpa/ConstraintTransformerJpaImpl.java
@@ -90,8 +90,12 @@ public class ConstraintTransformerJpaImpl extends ConstraintTransformer<Predicat
 
 	@SuppressWarnings("rawtypes")
 	private From<?,?> join(From<?,?> source, String attributeName) {
-		Optional<Join> existingJoin = source.getJoins().stream().filter(join->join.getAttribute().getName().equals(attributeName)).map(join->(Join)join).findFirst();
-		return existingJoin.orElseGet(()->source.join(attributeName, currentJoinType));
+		Optional<Join> existingJoin = source.getJoins().stream()
+				.map(join -> (Join) join)
+				.filter(join -> join.getAttribute().getName().equals(attributeName))
+				.filter(join -> join.getJoinType() == currentJoinType)
+				.findFirst();
+		return existingJoin.orElseGet(() -> source.join(attributeName, currentJoinType));
 	}
 	
 	private static Class<?> boxed(Class<?> type) {

--- a/backend-core-data-impl/src/test/java/com/flowingcode/backendcore/dao/jpa/JpaDaoSupportTest.java
+++ b/backend-core-data-impl/src/test/java/com/flowingcode/backendcore/dao/jpa/JpaDaoSupportTest.java
@@ -169,6 +169,25 @@ class JpaDaoSupportTest {
 	}
 
 	@Test
+	void testIsNullConstraintAfterOrDoesNotMatchAbsentCity() {
+		// Without the OR, city.population IS NULL correctly returns 0:
+		// persistedPerson has no city, so the INNER JOIN on city excludes them.
+		PersonFilter baseline = new PersonFilter();
+		baseline.addConstraint(ConstraintBuilder.of("id").equal(persistedPerson.getId()));
+		baseline.addConstraint(ConstraintBuilder.of("city", "population").isNull());
+		assertEquals(0, dao.count(baseline));
+
+		// Adding an OR that includes persistedPerson should not change the result:
+		// the IS NULL constraint still requires city to exist, regardless of the OR.
+		PersonFilter withOr = new PersonFilter();
+		withOr.addConstraint(
+			ConstraintBuilder.of("city", "id").equal(cities.get(0).getId())
+				.or(ConstraintBuilder.of("id").equal(persistedPerson.getId())));
+		withOr.addConstraint(ConstraintBuilder.of("city", "population").isNull());
+		assertEquals(0, dao.count(withOr));
+	}
+
+	@Test
 	@Disabled
 	void testDelete() {
 		fail("Not yet implemented");


### PR DESCRIPTION
Close #111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved join detection logic in persistence queries to ensure joins are correctly matched and reused based on both attribute matching and join type compatibility.

* **Tests**
  * Added test coverage for complex filter scenarios involving null constraints combined with logical operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->